### PR TITLE
Avoid credential literals in OpenUI skill guidance

### DIFF
--- a/skills/openui/SKILL.md
+++ b/skills/openui/SKILL.md
@@ -87,10 +87,12 @@ If “migrate” does not establish whether Cloud should replace the self-hosted
 
 ### Scaffold
 
+Never generate, print, or echo API key values. Ask the user to configure required credentials through their secret manager or an untracked local environment file.
+
 ```bash
 npx @openuidev/cli@latest create --name genui-chat-app --template openui-self-hosted --no-skill --no-interactive
 cd genui-chat-app
-echo "OPENAI_API_KEY=sk-your-key-here" > .env
+# Configure OPENAI_API_KEY in an untracked .env file before starting the app.
 npm run dev
 ```
 
@@ -104,7 +106,7 @@ npx @openuidev/cli@latest create --name genui-chat-app --template openui-self-ho
 
 If scaffold install/build fails with `ERR_PNPM_IGNORED_BUILDS` for native packages such as `sharp` or `unrs-resolver`, do not treat the scaffold as broken. Run `pnpm approve-builds` or `pnpm approve-builds --all`, then rerun install/build in an environment where package build scripts are allowed. Use first-party GitHub examples for Vue, Svelte, React Native, LangGraph, Mastra, Supabase, Vercel AI SDK, and other integrations.
 
-For self-hosted template build checks, set `OPENAI_API_KEY` even if no real model call is made. The generated Next route creates the OpenAI client at module scope, so `OPENAI_API_KEY=sk-test pnpm run build` is a valid smoke test when no real request will be sent.
+For self-hosted template build checks, set `OPENAI_API_KEY` even if no real model call is made. The generated Next route creates the OpenAI client at module scope. For a no-call smoke test, configure the variable with a non-secret placeholder through the process environment or an untracked local environment file, then run `pnpm run build`; never use a production credential.
 
 ### Choose OpenUI Cloud or self-hosted
 

--- a/skills/openui/SKILL.md
+++ b/skills/openui/SKILL.md
@@ -87,12 +87,12 @@ If “migrate” does not establish whether Cloud should replace the self-hosted
 
 ### Scaffold
 
-Never generate, print, or echo API key values. Ask the user to configure required credentials through their secret manager or an untracked local environment file.
+Never generate, print, echo, or invent placeholder API key values, and never ask the user to paste credentials into chat. Ask the user to configure required credentials outside the agent through their secret manager or an untracked local environment file. In generated commands, name the required variable but never emit a credential `NAME=value` assignment.
 
 ```bash
 npx @openuidev/cli@latest create --name genui-chat-app --template openui-self-hosted --no-skill --no-interactive
 cd genui-chat-app
-# Configure OPENAI_API_KEY in an untracked .env file before starting the app.
+# Confirm OPENAI_API_KEY is configured outside chat before starting the app.
 npm run dev
 ```
 
@@ -106,7 +106,7 @@ npx @openuidev/cli@latest create --name genui-chat-app --template openui-self-ho
 
 If scaffold install/build fails with `ERR_PNPM_IGNORED_BUILDS` for native packages such as `sharp` or `unrs-resolver`, do not treat the scaffold as broken. Run `pnpm approve-builds` or `pnpm approve-builds --all`, then rerun install/build in an environment where package build scripts are allowed. Use first-party GitHub examples for Vue, Svelte, React Native, LangGraph, Mastra, Supabase, Vercel AI SDK, and other integrations.
 
-For self-hosted template build checks, set `OPENAI_API_KEY` even if no real model call is made. The generated Next route creates the OpenAI client at module scope. For a no-call smoke test, configure the variable with a non-secret placeholder through the process environment or an untracked local environment file, then run `pnpm run build`; never use a production credential.
+For self-hosted template build checks, set `OPENAI_API_KEY` even if no real model call is made. The generated Next route creates the OpenAI client at module scope. For a no-call smoke test, require the variable to be preconfigured outside agent-generated commands, then run `pnpm run build`; do not emit an inline assignment or placeholder value, and never use a production credential.
 
 ### Choose OpenUI Cloud or self-hosted
 

--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -59,10 +59,9 @@ zustand@^4.5.5
 
 `@openuidev/react-ui` re-exports headless APIs, but keep `@openuidev/react-headless` installed when required as a peer dependency. Import the re-exported APIs from `@openuidev/react-ui` in React UI applications.
 
-Configure server-only environment values:
+Configure server-only environment values through the deployment secret manager or an untracked `.env.local` file. Define `THESYS_API_KEY` there without printing, echoing, or committing its value.
 
 ```bash
-THESYS_API_KEY=sk-th-your-key
 OPENUI_MODEL=google/gemini-3.1-pro-free
 ```
 

--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -59,7 +59,7 @@ zustand@^4.5.5
 
 `@openuidev/react-ui` re-exports headless APIs, but keep `@openuidev/react-headless` installed when required as a peer dependency. Import the re-exported APIs from `@openuidev/react-ui` in React UI applications.
 
-Configure server-only environment values through the deployment secret manager or an untracked `.env.local` file. Define `THESYS_API_KEY` there without printing, echoing, or committing its value.
+Configure server-only environment values through the deployment secret manager or an untracked `.env.local` file. Define `THESYS_API_KEY` there without printing, echoing, or committing its value. Never output a credential `NAME=value` example, even with a placeholder value.
 
 ```bash
 OPENUI_MODEL=google/gemini-3.1-pro-free

--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -414,10 +414,11 @@ tools: [
     type: "mcp",
     server_label: "deepwiki",
     server_url: "https://mcp.deepwiki.com/mcp", // public, no auth — good smoke test
-    // headers: { Authorization: `Bearer ${process.env.MCP_TOKEN}` },
   },
 ],
 ```
+
+For an authenticated MCP server, load credentials from existing server-side secret storage and attach them only to an explicitly approved provider origin. Never put token values in generated output, client code, or logs.
 
 MCP servers do not auto-attach; every request declares its own. The stream carries an `mcp_list_tools` item once per fresh server and one `mcp_call` item per invocation. A failed connection surfaces as `mcp_list_tools` with an `error` field — check for it before concluding the model "chose not to" use the server.
 


### PR DESCRIPTION
## Summary

- remove literal secret-shaped API key examples from the OpenUI skill
- direct users to configure credentials through secret managers or untracked local environment files
- remove the example that forwards an environment token to a remote MCP server and document an approved-origin boundary instead

## Why

The skills.sh Snyk audit currently marks the OpenUI skill as **High Risk (W007: insecure credential handling)**. It specifically identifies the literal `sk-*` values embedded in shell commands as encouraging agents to emit secret-like values directly.

This change keeps the setup and no-call build guidance intact without printing, echoing, inlining, or committing credential values. It also removes the remaining secret-shaped Thesys placeholder from the supporting Cloud reference.

Audit: https://skills.sh/thesysdev/skills/openui/security/snyk

## Validation

- OpenUI skill validation passes with `quick_validate.py`
- no `sk-*`, `OPENAI_API_KEY=...`, or `THESYS_API_KEY=...` literal assignments remain in the skill tree
- `git diff --check`
- a fresh forward-test of the scaffold/build workflow emitted no credential assignments or placeholder values

## Compatibility mirror

The same change is mirrored in [thesysdev/openui#860](https://github.com/thesysdev/openui/pull/860) for `@openuidev/cli` 0.0.7–0.1.7, which still installs from the OpenUI repository. Merge this canonical PR first, then verify the mirror still matches its final contents.

Tracking: [TH-2427](https://linear.app/thesys/issue/TH-2427/maintain-parity-between-thesysdevskills-and-openuiskills)
