### PR TITLE
TH-2472: Fix third-party content exposure finding

### DIFF
--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -218,6 +218,22 @@ Validate input, authorize the untrusted `threadId` for the authenticated user,
 keep the key server-side, forward the abort signal, and return Responses SSE
 without converting protocols.
 
+### User-input trust boundary
+
+The generation proxy accepts only text authored directly by the authenticated
+user for that user's authorized conversation. This is the product's intended
+chat input; the route does not fetch or ingest content from arbitrary URLs,
+public websites, social media, shared feeds, or other third-party sources.
+
+Treat the text as untrusted application input and preserve it strictly as a
+`role: "user"` message. Never concatenate it into system, developer, or
+`instructions` content, and never use it to select credentials, models, tool
+definitions, or authorization policy. Authenticate and rate-limit the route,
+bound and validate the request, authorize the conversation independently, and
+enforce tool permissions outside the model. If a future feature accepts URLs,
+files, search results, or tool output, handle that content as a separate
+untrusted-data path with explicit source, size, and capability controls.
+
 Create a server-only `parseCloudChatRequest(req)` helper before enabling the
 route. Require JSON, accept a bounded `threadId`, allow exactly one bounded text item with
 `{ type: "message", role: "user" }`, and reconstruct the provider item from


### PR DESCRIPTION
## Summary

- clarify that the generation proxy accepts only direct, authenticated user-authored chat text
- document that the workflow does not ingest arbitrary URLs, websites, feeds, or other third-party sources
- preserve untrusted input as a `user` message and define controls for any future external-content path

## Why

Snyk Agent Scan reported W011, Third-Party Content Exposure, because it interpreted browser-supplied chat text as third-party content. The workflow already treats this as bounded first-party chat input; this change makes that trust boundary and the required safeguards explicit.

## Validation

- Snyk Agent Scan: **No issues found** across all 9 security checks
- `git diff --check`
<img width="1050" height="908" alt="image" src="https://github.com/user-attachments/assets/c75a2818-6280-433e-bb2f-a99da15c5dde" />


## Linear

References TH-2472

[Fix third-party content exposure finding from Snyk skill scan](https://linear.app/thesys/issue/TH-2472/fix-third-party-content-exposure-finding-from-snyk-skill-scan)
