### PR TITLE
docs: document OpenUI Cloud BYOK

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Agent-ready guidance for building generative interfaces with [OpenUI](https://ww
 - Stream and render OpenUI Lang in React, Vue, Svelte, and browser-based apps.
 - Build custom component libraries with typed schemas, state, actions, queries, and mutations.
 - Add `AgentInterface` to new or existing chat applications.
-- Choose between self-hosted OpenUI and OpenUI Cloud, including Cloud BYOK with OpenAI, Anthropic, or Google keys on any plan, including the free tier.
+- Choose between self-hosted OpenUI and OpenUI Cloud, including Cloud BYOK with OpenAI or Anthropic API keys, or Google Cloud service-account credentials, on any plan, including the free tier.
 - Migrate legacy JSON UI or self-hosted OpenUI implementations.
 - Debug prompts, parsers, renderers, adapters, storage, theming, tools, and artifacts.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Agent-ready guidance for building generative interfaces with [OpenUI](https://ww
 - Stream and render OpenUI Lang in React, Vue, Svelte, and browser-based apps.
 - Build custom component libraries with typed schemas, state, actions, queries, and mutations.
 - Add `AgentInterface` to new or existing chat applications.
-- Choose between self-hosted OpenUI and OpenUI Cloud, then integrate the selected backend safely.
+- Choose between self-hosted OpenUI and OpenUI Cloud, including Cloud BYOK with OpenAI, Anthropic, or Google keys on any plan, including the free tier.
 - Migrate legacy JSON UI or self-hosted OpenUI implementations.
 - Debug prompts, parsers, renderers, adapters, storage, theming, tools, and artifacts.
 

--- a/skills/openui/SKILL.md
+++ b/skills/openui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openui
-description: "Use for building, debugging, integrating, migrating, or documenting OpenUI, OpenUI Lang, Agent Interface, OpenUI Cloud, @openuidev packages, streaming generative UI rendering, component libraries, existing-project Cloud integration, self-hosted-to-Cloud migration, migrations from JSON UI formats, Cloud tools (web/image search, artifacts), remote MCP servers, custom function tools and tool loops, and multi-user or multi-app identity (frontend tokens, app_id/user_id, conversation APIs, Responses metadata)."
+description: "Use for building, debugging, integrating, migrating, or documenting OpenUI, OpenUI Lang, Agent Interface, OpenUI Cloud, @openuidev packages, streaming generative UI rendering, component libraries, existing-project Cloud integration, Cloud BYOK, self-hosted-to-Cloud migration, migrations from JSON UI formats, Cloud tools (web/image search, artifacts), remote MCP servers, custom function tools and tool loops, and multi-user or multi-app identity (frontend tokens, app_id/user_id, conversation APIs, Responses metadata)."
 ---
 
 # OpenUI
@@ -56,6 +56,7 @@ OpenUI Cloud speaks the OpenAI Responses API (`POST https://api.thesys.dev/v1/em
 | Generative UI (OpenUI Lang) | Default response format, streamed in Responses-compatible events |
 | Output validation & correction | Invalid model output detected and corrected in-stream; sanitized fallback — no broken UI reaches the renderer |
 | Managed model access | Leading providers behind one API (billed at cost), automatic model/provider fallbacks; models list endpoint |
+| Bring your own model key (BYOK) | Add an OpenAI, Anthropic, or Google API key from the [BYOK page in the Thesys console](https://console.thesys.dev/byok); available on every plan, including the free tier |
 | Artifacts: slides + reports | `artifactTool({ artifacts: ["slides", "report"] })` — generated server-side; **editing is automatically enabled** (the model edits existing artifacts on follow-up asks, no extra config), rendered in the managed viewer |
 | Web search | `{ type: "web_search" }` — runs server-side |
 | Image search | `{ type: "image_search" }` — runs server-side |
@@ -110,7 +111,7 @@ For self-hosted template build checks, set `OPENAI_API_KEY` even if no real mode
 
 ### Choose OpenUI Cloud or self-hosted
 
-OpenUI Cloud is the managed backend for Agent Interface. It uses the open-source OpenUI rendering engine and adds production layers: persisted conversations, production-grade generative UI, prebuilt report/presentation artifacts, theming/white-labeling, output correction, model/provider resilience, versioning, observability, and audit trails.
+OpenUI Cloud is the managed backend for Agent Interface. It uses the open-source OpenUI rendering engine and adds production layers: persisted conversations, production-grade generative UI, managed models or BYOK, prebuilt report/presentation artifacts, theming/white-labeling, output correction, model/provider resilience, versioning, observability, and audit trails.
 
 Use Cloud when the user wants managed production infrastructure for an Agent Interface app. Use self-hosted OpenUI when the user wants to own the model route, storage, tools, component library, and runtime behavior.
 
@@ -123,6 +124,7 @@ Version-sensitive: verify exact Cloud template env vars, `@openuidev/thesys*` ex
 - `AgentInterface` connects to Cloud with `llm` and `storage` props. `llm` points to an app route that proxies Cloud's Responses endpoint, usually with `openAIResponsesAdapter()` and `openAIConversationMessageFormat`. `storage` uses `useOpenuiCloudStorage()` from `@openuidev/thesys` with a short-lived frontend token.
 - Cloud-provided component sets, artifact renderers, and categories come from `@openuidev/thesys`.
 - Generate keys in the Thesys console: `https://console.thesys.dev/keys`.
+- To use your own model provider, add an OpenAI, Anthropic, or Google API key from `https://console.thesys.dev/byok`. BYOK is available on every plan, including the free tier; configure provider keys in the console rather than adding them to the application.
 
 For existing-project Cloud work, keep these invariants intact:
 

--- a/skills/openui/SKILL.md
+++ b/skills/openui/SKILL.md
@@ -56,8 +56,7 @@ OpenUI Cloud speaks the OpenAI Responses API (`POST https://api.thesys.dev/v1/em
 | Generative UI (OpenUI Lang) | Default response format, streamed in Responses-compatible events |
 | Output validation & correction | Invalid model output detected and corrected in-stream; sanitized fallback — no broken UI reaches the renderer |
 | Managed model access | Leading providers behind one API (billed at cost), automatic model/provider fallbacks; models list endpoint |
-| Bring your own model credentials (BYOK) | Organization admins add an OpenAI or Anthropic API key, or Google Cloud service-account credentials, from the [BYOK page in the Thesys console](https://console.thesys.dev/byok); every organization member can then use that provider on every plan, including the free tier |
-| Cloud model selection | Managed access and BYOK use the same `provider/model` identifiers; verify the current list on the [Models and BYOK page](https://www.openui.com/docs/openui-cloud/models-and-byok) before hardcoding one |
+| Bring your own model credentials (BYOK) | Available on every plan; read [Configure BYOK](references/cloud-integration.md#configure-byok) for provider credential formats, organization access, billing, model identifiers, and the required human handoff |
 | Artifacts: slides + reports | `artifactTool({ artifacts: ["slides", "report"] })` — generated server-side; **editing is automatically enabled** (the model edits existing artifacts on follow-up asks, no extra config), rendered in the managed viewer |
 | Web search | `{ type: "web_search" }` — runs server-side |
 | Image search | `{ type: "image_search" }` — runs server-side |
@@ -69,7 +68,7 @@ OpenUI Cloud speaks the OpenAI Responses API (`POST https://api.thesys.dev/v1/em
 | Standard OpenAI Responses params | Being Responses-compatible, `previous_response_id`, `stream: false`, `instructions`, `tool_choice`, `parallel_tool_calls`, `safety_identifier` work as documented by OpenAI — production setups here use `conversation` + `store: true` + streaming |
 | Responsive managed UI | `AgentInterface` + `chatLibrary` |
 
-Tools/MCP and multi-user are steps 8-9 of [references/cloud-integration.md](references/cloud-integration.md).
+Tools/MCP and multi-user are steps 9-10 of [references/cloud-integration.md](references/cloud-integration.md).
 
 ## Route Cloud Integration and Migration Tasks
 
@@ -125,11 +124,7 @@ Version-sensitive: verify exact Cloud template env vars, `@openuidev/thesys*` ex
 - `AgentInterface` connects to Cloud with `llm` and `storage` props. `llm` points to an app route that proxies Cloud's Responses endpoint, usually with `openAIResponsesAdapter()` and `openAIConversationMessageFormat`. `storage` uses `useOpenuiCloudStorage()` from `@openuidev/thesys` with a short-lived frontend token.
 - Cloud-provided component sets, artifact renderers, and categories come from `@openuidev/thesys`.
 - Generate keys in the Thesys console: `https://console.thesys.dev/keys`.
-- To use your own model provider, add an OpenAI or Anthropic API key from `https://console.thesys.dev/byok`. For Google-hosted Gemini models, the console expects GCP service-account JSON plus a `region` field, not a single Google AI Studio/Gemini API key. BYOK is available on every plan, including the free tier.
-- Only organization admins can add or update provider credentials. After an admin saves one, every organization member can use BYOK models from that provider.
-- BYOK is provider-specific: requests to the matching provider use the organization's credential. Requests to another provider use OpenUI Cloud credits and fail with an out-of-credits error when no credits remain.
-- Managed access and BYOK share the same `provider/model` identifiers. Verify the current supported BYOK model list on the first-party Models and BYOK page before changing `OPENUI_MODEL` or hardcoding an allowlist.
-- Use a human-in-the-loop handoff for provider credentials: explain the provider-specific credential shape and give the user the BYOK console URL, then ask them to log in, enter, and save the credential directly. Never ask for or accept an API key or service-account JSON in chat, and do not invent IAM roles, credential fields, or region values that are not verified by current first-party instructions. After the user confirms the credential is saved, resume only with non-secret verification such as checking the selected model or testing a request. If a credential already appeared in model context, treat it as exposed and recommend rotation before setup.
+- Before assisting with model-provider credentials, read [Configure BYOK](references/cloud-integration.md#configure-byok) completely. Keep the credential entry human-in-the-loop.
 
 For existing-project Cloud work, keep these invariants intact:
 

--- a/skills/openui/SKILL.md
+++ b/skills/openui/SKILL.md
@@ -56,7 +56,8 @@ OpenUI Cloud speaks the OpenAI Responses API (`POST https://api.thesys.dev/v1/em
 | Generative UI (OpenUI Lang) | Default response format, streamed in Responses-compatible events |
 | Output validation & correction | Invalid model output detected and corrected in-stream; sanitized fallback — no broken UI reaches the renderer |
 | Managed model access | Leading providers behind one API (billed at cost), automatic model/provider fallbacks; models list endpoint |
-| Bring your own model credentials (BYOK) | Add an OpenAI or Anthropic API key, or Google Cloud service-account credentials, from the [BYOK page in the Thesys console](https://console.thesys.dev/byok); available on every plan, including the free tier |
+| Bring your own model credentials (BYOK) | Organization admins add an OpenAI or Anthropic API key, or Google Cloud service-account credentials, from the [BYOK page in the Thesys console](https://console.thesys.dev/byok); every organization member can then use that provider on every plan, including the free tier |
+| Cloud model selection | Managed access and BYOK use the same `provider/model` identifiers; verify the current list on the [Models and BYOK page](https://www.openui.com/docs/openui-cloud/models-and-byok) before hardcoding one |
 | Artifacts: slides + reports | `artifactTool({ artifacts: ["slides", "report"] })` — generated server-side; **editing is automatically enabled** (the model edits existing artifacts on follow-up asks, no extra config), rendered in the managed viewer |
 | Web search | `{ type: "web_search" }` — runs server-side |
 | Image search | `{ type: "image_search" }` — runs server-side |
@@ -125,6 +126,9 @@ Version-sensitive: verify exact Cloud template env vars, `@openuidev/thesys*` ex
 - Cloud-provided component sets, artifact renderers, and categories come from `@openuidev/thesys`.
 - Generate keys in the Thesys console: `https://console.thesys.dev/keys`.
 - To use your own model provider, add an OpenAI or Anthropic API key from `https://console.thesys.dev/byok`. For Google-hosted Gemini models, the console expects GCP service-account JSON plus a `region` field, not a single Google AI Studio/Gemini API key. BYOK is available on every plan, including the free tier.
+- Only organization admins can add or update provider credentials. After an admin saves one, every organization member can use BYOK models from that provider.
+- BYOK is provider-specific: requests to the matching provider use the organization's credential. Requests to another provider use OpenUI Cloud credits and fail with an out-of-credits error when no credits remain.
+- Managed access and BYOK share the same `provider/model` identifiers. Verify the current supported BYOK model list on the first-party Models and BYOK page before changing `OPENUI_MODEL` or hardcoding an allowlist.
 - Use a human-in-the-loop handoff for provider credentials: explain the provider-specific credential shape and give the user the BYOK console URL, then ask them to log in, enter, and save the credential directly. Never ask for or accept an API key or service-account JSON in chat, and do not invent IAM roles, credential fields, or region values that are not verified by current first-party instructions. After the user confirms the credential is saved, resume only with non-secret verification such as checking the selected model or testing a request. If a credential already appeared in model context, treat it as exposed and recommend rotation before setup.
 
 For existing-project Cloud work, keep these invariants intact:

--- a/skills/openui/SKILL.md
+++ b/skills/openui/SKILL.md
@@ -56,7 +56,7 @@ OpenUI Cloud speaks the OpenAI Responses API (`POST https://api.thesys.dev/v1/em
 | Generative UI (OpenUI Lang) | Default response format, streamed in Responses-compatible events |
 | Output validation & correction | Invalid model output detected and corrected in-stream; sanitized fallback — no broken UI reaches the renderer |
 | Managed model access | Leading providers behind one API (billed at cost), automatic model/provider fallbacks; models list endpoint |
-| Bring your own model key (BYOK) | Add an OpenAI, Anthropic, or Google API key from the [BYOK page in the Thesys console](https://console.thesys.dev/byok); available on every plan, including the free tier |
+| Bring your own model credentials (BYOK) | Add an OpenAI or Anthropic API key, or Google Cloud service-account credentials, from the [BYOK page in the Thesys console](https://console.thesys.dev/byok); available on every plan, including the free tier |
 | Artifacts: slides + reports | `artifactTool({ artifacts: ["slides", "report"] })` — generated server-side; **editing is automatically enabled** (the model edits existing artifacts on follow-up asks, no extra config), rendered in the managed viewer |
 | Web search | `{ type: "web_search" }` — runs server-side |
 | Image search | `{ type: "image_search" }` — runs server-side |
@@ -124,7 +124,8 @@ Version-sensitive: verify exact Cloud template env vars, `@openuidev/thesys*` ex
 - `AgentInterface` connects to Cloud with `llm` and `storage` props. `llm` points to an app route that proxies Cloud's Responses endpoint, usually with `openAIResponsesAdapter()` and `openAIConversationMessageFormat`. `storage` uses `useOpenuiCloudStorage()` from `@openuidev/thesys` with a short-lived frontend token.
 - Cloud-provided component sets, artifact renderers, and categories come from `@openuidev/thesys`.
 - Generate keys in the Thesys console: `https://console.thesys.dev/keys`.
-- To use your own model provider, add an OpenAI, Anthropic, or Google API key from `https://console.thesys.dev/byok`. BYOK is available on every plan, including the free tier; configure provider keys in the console rather than adding them to the application.
+- To use your own model provider, add an OpenAI or Anthropic API key from `https://console.thesys.dev/byok`. For Google-hosted Gemini models, the console expects GCP service-account JSON plus a `region` field, not a single Google AI Studio/Gemini API key. BYOK is available on every plan, including the free tier.
+- Configure provider credentials in the console rather than adding them to the application. An agent may navigate to the BYOK page, but if login or credential entry is required, it must stop and ask the user to take over. Never ask for, accept, print, or type an API key or service-account JSON through model context or computer-use actions. If a credential already appeared in model context, treat it as exposed and recommend rotation.
 
 For existing-project Cloud work, keep these invariants intact:
 

--- a/skills/openui/SKILL.md
+++ b/skills/openui/SKILL.md
@@ -125,7 +125,7 @@ Version-sensitive: verify exact Cloud template env vars, `@openuidev/thesys*` ex
 - Cloud-provided component sets, artifact renderers, and categories come from `@openuidev/thesys`.
 - Generate keys in the Thesys console: `https://console.thesys.dev/keys`.
 - To use your own model provider, add an OpenAI or Anthropic API key from `https://console.thesys.dev/byok`. For Google-hosted Gemini models, the console expects GCP service-account JSON plus a `region` field, not a single Google AI Studio/Gemini API key. BYOK is available on every plan, including the free tier.
-- Configure provider credentials in the console rather than adding them to the application. An agent may navigate to the BYOK page, but if login or credential entry is required, it must stop and ask the user to take over. Never ask for, accept, print, or type an API key or service-account JSON through model context or computer-use actions. If a credential already appeared in model context, treat it as exposed and recommend rotation.
+- Use a human-in-the-loop handoff for provider credentials: explain the provider-specific credential shape and give the user the BYOK console URL, then ask them to log in, enter, and save the credential directly. Never ask for or accept an API key or service-account JSON in chat, and do not invent IAM roles, credential fields, or region values that are not verified by current first-party instructions. After the user confirms the credential is saved, resume only with non-secret verification such as checking the selected model or testing a request. If a credential already appeared in model context, treat it as exposed and recommend rotation before setup.
 
 For existing-project Cloud work, keep these invariants intact:
 

--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -61,7 +61,9 @@ zustand@^4.5.5
 
 Configure server-only environment values through the deployment secret manager or an untracked `.env.local` file. Define `THESYS_API_KEY` there without printing, echoing, or committing its value. Never output a credential `NAME=value` example, even with a placeholder value.
 
-OpenUI Cloud also supports bringing an OpenAI, Anthropic, or Google API key on every plan, including the free tier. Add the provider key from the [BYOK page in the Thesys console](https://console.thesys.dev/byok), not to the generated application's environment or client code. The application still uses its server-side `THESYS_API_KEY` to call OpenUI Cloud; BYOK changes the model-provider billing path, not the application authentication boundary.
+OpenUI Cloud supports bringing an OpenAI or Anthropic API key on every plan, including the free tier. Google-hosted Gemini models use a different credential shape: the console expects the full GCP service-account JSON plus a `region` field, not a single Google AI Studio/Gemini API key. Use a dedicated, least-privilege service account and follow the console's current required fields; do not reproduce a service-account JSON template in generated output.
+
+Add provider credentials from the [BYOK page in the Thesys console](https://console.thesys.dev/byok), not to the generated application's environment or client code. An agent may navigate to the page, but if login or credential entry is required, it must pause and ask the user to take over. Never ask the user to put an API key or service-account JSON in chat, and never move one from model context into the form with computer use. Treat a credential that already appeared in model context as exposed and recommend rotation. The application still uses its server-side `THESYS_API_KEY` to call OpenUI Cloud; BYOK changes the model-provider billing path, not the application authentication boundary.
 
 ```bash
 OPENUI_MODEL=google/gemini-3.1-pro-free

--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -71,11 +71,38 @@ Add provider credentials from the [BYOK page in the Thesys console](https://cons
 
 Treat a credential that already appeared in model context as exposed and recommend rotation before setup. The application still uses its server-side `THESYS_API_KEY` to call OpenUI Cloud; BYOK changes the model-provider billing path, not the application authentication boundary.
 
+### BYOK access, billing, and model selection
+
+Only organization admins can add or update provider credentials. After an admin saves a credential, every member of that organization can use BYOK models from the matching provider.
+
+BYOK is provider-specific. A request to the provider whose credential the organization added uses that credential. A request to a different provider uses OpenUI Cloud credits instead; when the organization has no credits, the unmatched-provider request fails with an out-of-credits error. Do not imply that adding one provider credential enables BYOK billing for other providers.
+
+Managed model access and BYOK use the same `provider/model` identifiers. The current first-party BYOK list is:
+
+| Provider | Model | Identifier |
+|---|---|---|
+| Anthropic | Claude Sonnet 5 | `anthropic/claude-sonnet-5` |
+| Anthropic | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4.6` |
+| Anthropic | Claude Opus 4.7 | `anthropic/claude-opus-4-7` |
+| Google | Gemini 3.6 Flash | `google/gemini-3.6-flash` |
+| Google | Gemini 3.5 Flash | `google/gemini-3.5-flash` |
+| Google | Gemini 3.1 Pro Preview | `google/gemini-3.1-pro-preview` |
+| OpenAI | GPT-5.5 | `openai/gpt-5.5` |
+| OpenAI | GPT-5.4 | `openai/gpt-5.4` |
+| OpenAI | GPT-5.4 mini | `openai/gpt-5.4-mini` |
+| OpenAI | GPT-5.2 | `openai/gpt-5.2` |
+| OpenAI | GPT-5.1 | `openai/gpt-5.1` |
+| OpenAI | GPT-5 | `openai/gpt-5` |
+
+Model availability is version-sensitive. Verify identifiers against the [first-party Models and BYOK page](https://www.openui.com/docs/openui-cloud/models-and-byok), the console, or the generated template before changing `OPENUI_MODEL` or a production allowlist.
+
+A generated scaffold may use a managed/free model by default, for example:
+
 ```bash
 OPENUI_MODEL=google/gemini-3.1-pro-free
 ```
 
-Use a current supported `provider/model` value for `OPENUI_MODEL`; prefer the generated template or console over a stale hardcoded list. A scaffold may also use `DEMO_USER_ID=demo-user`, but production must derive the user id from authenticated server state.
+For BYOK, replace that value with a current supported BYOK identifier. A scaffold may also use `DEMO_USER_ID=demo-user`, but production must derive the user id from authenticated server state.
 
 ## Wire the Client
 

--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -61,6 +61,8 @@ zustand@^4.5.5
 
 Configure server-only environment values through the deployment secret manager or an untracked `.env.local` file. Define `THESYS_API_KEY` there without printing, echoing, or committing its value. Never output a credential `NAME=value` example, even with a placeholder value.
 
+OpenUI Cloud also supports bringing an OpenAI, Anthropic, or Google API key on every plan, including the free tier. Add the provider key from the [BYOK page in the Thesys console](https://console.thesys.dev/byok), not to the generated application's environment or client code. The application still uses its server-side `THESYS_API_KEY` to call OpenUI Cloud; BYOK changes the model-provider billing path, not the application authentication boundary.
+
 ```bash
 OPENUI_MODEL=google/gemini-3.1-pro-free
 ```

--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -63,7 +63,13 @@ Configure server-only environment values through the deployment secret manager o
 
 OpenUI Cloud supports bringing an OpenAI or Anthropic API key on every plan, including the free tier. Google-hosted Gemini models use a different credential shape: the console expects the full GCP service-account JSON plus a `region` field, not a single Google AI Studio/Gemini API key. Use a dedicated, least-privilege service account and follow the console's current required fields; do not reproduce a service-account JSON template in generated output.
 
-Add provider credentials from the [BYOK page in the Thesys console](https://console.thesys.dev/byok), not to the generated application's environment or client code. An agent may navigate to the page, but if login or credential entry is required, it must pause and ask the user to take over. Never ask the user to put an API key or service-account JSON in chat, and never move one from model context into the form with computer use. Treat a credential that already appeared in model context as exposed and recommend rotation. The application still uses its server-side `THESYS_API_KEY` to call OpenUI Cloud; BYOK changes the model-provider billing path, not the application authentication boundary.
+Add provider credentials from the [BYOK page in the Thesys console](https://console.thesys.dev/byok), not to the generated application's environment or client code. Use this human-in-the-loop handoff:
+
+1. **Prepare:** Explain the provider-specific credential shape, the Google `region` requirement when applicable, and the console URL without requesting any sensitive value. Do not invent IAM roles, credential fields, or region values; use current first-party console or provider instructions.
+2. **Human checkpoint:** Ask the user to log in and enter and save the provider credential directly in the console. Wait for the user to confirm completion; never ask them to put an API key or service-account JSON in chat.
+3. **Resume:** After confirmation, continue only with non-secret verification, such as checking the selected model or testing a request. Never inspect or reproduce the stored credential.
+
+Treat a credential that already appeared in model context as exposed and recommend rotation before setup. The application still uses its server-side `THESYS_API_KEY` to call OpenUI Cloud; BYOK changes the model-provider billing path, not the application authentication boundary.
 
 ```bash
 OPENUI_MODEL=google/gemini-3.1-pro-free

--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -7,14 +7,15 @@ Use this runbook to add the stock OpenUI Cloud Agent Interface to an existing Re
 1. [Supported Contract](#supported-contract)
 2. [Audit the Host](#audit-the-host)
 3. [Install and Configure](#install-and-configure)
-4. [Wire the Client](#wire-the-client)
-5. [Authorize Cloud Conversations](#authorize-cloud-conversations)
-6. [Add the Generation Proxy](#add-the-generation-proxy)
-7. [Add the Frontend Token Route](#add-the-frontend-token-route)
-8. [Add Tools and MCP](#add-tools-and-mcp)
-9. [Multi-User and Multi-App Convention](#multi-user-and-multi-app-convention)
-10. [Adapt Beyond Next.js](#adapt-beyond-nextjs)
-11. [Verify](#verify)
+4. [Configure BYOK](#configure-byok)
+5. [Wire the Client](#wire-the-client)
+6. [Authorize Cloud Conversations](#authorize-cloud-conversations)
+7. [Add the Generation Proxy](#add-the-generation-proxy)
+8. [Add the Frontend Token Route](#add-the-frontend-token-route)
+9. [Add Tools and MCP](#add-tools-and-mcp)
+10. [Multi-User and Multi-App Convention](#multi-user-and-multi-app-convention)
+11. [Adapt Beyond Next.js](#adapt-beyond-nextjs)
+12. [Verify](#verify)
 
 ## Supported Contract
 
@@ -61,21 +62,33 @@ zustand@^4.5.5
 
 Configure server-only environment values through the deployment secret manager or an untracked `.env.local` file. Define `THESYS_API_KEY` there without printing, echoing, or committing its value. Never output a credential `NAME=value` example, even with a placeholder value.
 
-OpenUI Cloud supports bringing an OpenAI or Anthropic API key on every plan, including the free tier. Google-hosted Gemini models use a different credential shape: the console expects the full GCP service-account JSON plus a `region` field, not a single Google AI Studio/Gemini API key. Use a dedicated, least-privilege service account and follow the console's current required fields; do not reproduce a service-account JSON template in generated output.
+## Configure BYOK
 
-Add provider credentials from the [BYOK page in the Thesys console](https://console.thesys.dev/byok), not to the generated application's environment or client code. Use this human-in-the-loop handoff:
+BYOK is available on every plan, including the free tier. Add provider credentials from the [BYOK page in the Thesys console](https://console.thesys.dev/byok), not to the generated application's environment or client code.
 
-1. **Prepare:** Explain the provider-specific credential shape, the Google `region` requirement when applicable, and the console URL without requesting any sensitive value. Do not invent IAM roles, credential fields, or region values; use current first-party console or provider instructions.
+### Provider credentials
+
+OpenAI and Anthropic accept API keys. Google-hosted Gemini models use a different credential shape: the console expects the full GCP service-account JSON plus a `region` field, not a single Google AI Studio/Gemini API key. Use a dedicated, least-privilege service account and follow the console's current required fields; do not reproduce a service-account JSON template in generated output.
+
+Do not invent IAM roles, credential fields, or region values. Use the current first-party console or provider instructions.
+
+### Human checkpoint
+
+Use this human-in-the-loop handoff:
+
+1. **Prepare:** Explain the provider-specific credential shape, the Google `region` requirement when applicable, and the console URL without requesting any sensitive value.
 2. **Human checkpoint:** Ask the user to log in and enter and save the provider credential directly in the console. Wait for the user to confirm completion; never ask them to put an API key or service-account JSON in chat.
 3. **Resume:** After confirmation, continue only with non-secret verification, such as checking the selected model or testing a request. Never inspect or reproduce the stored credential.
 
 Treat a credential that already appeared in model context as exposed and recommend rotation before setup. The application still uses its server-side `THESYS_API_KEY` to call OpenUI Cloud; BYOK changes the model-provider billing path, not the application authentication boundary.
 
-### BYOK access, billing, and model selection
+### Organization access and billing
 
 Only organization admins can add or update provider credentials. After an admin saves a credential, every member of that organization can use BYOK models from the matching provider.
 
 BYOK is provider-specific. A request to the provider whose credential the organization added uses that credential. A request to a different provider uses OpenUI Cloud credits instead; when the organization has no credits, the unmatched-provider request fails with an out-of-credits error. Do not imply that adding one provider credential enables BYOK billing for other providers.
+
+### Model selection
 
 Managed model access and BYOK use the same `provider/model` identifiers. The current first-party BYOK list is:
 


### PR DESCRIPTION
## Summary

- add BYOK to the OpenUI skill trigger and Cloud capability guidance
- keep the core skill concise and route detailed setup work to a first-class `Configure BYOK` section in the Cloud integration runbook
- document OpenAI and Anthropic API keys on every plan, including the free tier
- clarify that Google-hosted Gemini BYOK expects GCP service-account JSON plus a `region` field rather than a Google AI Studio/Gemini API key
- define a human-in-the-loop handoff: the agent explains the requirements, the user enters the credential directly, and the agent resumes with non-secret verification
- document organization-admin credential management and organization-wide access to the matching provider
- explain provider-specific billing, including Cloud-credit fallback and out-of-credits failures for unmatched providers
- list the current supported BYOK `provider/model` identifiers and require version-sensitive verification before hardcoding them
- prevent agents from inventing unverified IAM roles, credential fields, or region values
- clarify that applications still authenticate to OpenUI Cloud with a server-side `THESYS_API_KEY`

## Why

This carries the BYOK launch guidance from [thesysdev/openui#942](https://github.com/thesysdev/openui/pull/942) and [thesysdev/openui#947](https://github.com/thesysdev/openui/pull/947) into the OpenUI skill. Detailed BYOK behavior is grouped under one discoverable runbook section rather than duplicated across general Cloud setup guidance. It also captures the Google-specific credential shape shown by the current Thesys console while keeping credentials outside chat and generated application configuration.

## Validation

- passed the skill creator's `quick_validate.py`
- `git diff --check`
- parsed `skills/openui/SKILL.md` frontmatter with Ruby YAML
- confirmed all 12 current BYOK identifiers from `thesysdev/openui#947` are present
- confirmed no private-key signatures or credential templates were added
- confirmed `https://console.thesys.dev/byok` returns HTTP 200
- ran a Claude Sonnet 5 sandbox regression against the dev BYOK URL; it used the human checkpoint, avoided credential handling, and did not invent IAM roles or region values
