### PR TITLE
docs: refresh BYOK model examples

### DIFF
--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -90,24 +90,21 @@ BYOK is provider-specific. A request to the provider whose credential the organi
 
 ### Model selection
 
-Managed model access and BYOK use the same `provider/model` identifiers. The current first-party BYOK list is:
+Managed model access and BYOK use the same `provider/model` identifiers. All models available from Anthropic, Google, and OpenAI are supported with BYOK; this table is a non-exhaustive list of current examples:
 
 | Provider | Model | Identifier |
 |---|---|---|
+| Anthropic | Claude Opus 5 | `anthropic/claude-opus-5` |
 | Anthropic | Claude Sonnet 5 | `anthropic/claude-sonnet-5` |
-| Anthropic | Claude Sonnet 4.6 | `anthropic/claude-sonnet-4.6` |
 | Anthropic | Claude Opus 4.7 | `anthropic/claude-opus-4-7` |
 | Google | Gemini 3.6 Flash | `google/gemini-3.6-flash` |
 | Google | Gemini 3.5 Flash | `google/gemini-3.5-flash` |
 | Google | Gemini 3.1 Pro Preview | `google/gemini-3.1-pro-preview` |
+| OpenAI | GPT-5.6 Sol | `openai/gpt-5.6-sol` |
 | OpenAI | GPT-5.5 | `openai/gpt-5.5` |
 | OpenAI | GPT-5.4 | `openai/gpt-5.4` |
-| OpenAI | GPT-5.4 mini | `openai/gpt-5.4-mini` |
-| OpenAI | GPT-5.2 | `openai/gpt-5.2` |
-| OpenAI | GPT-5.1 | `openai/gpt-5.1` |
-| OpenAI | GPT-5 | `openai/gpt-5` |
 
-Model availability is version-sensitive. Verify identifiers against the [first-party Models and BYOK page](https://www.openui.com/docs/openui-cloud/models-and-byok), the console, or the generated template before changing `OPENUI_MODEL` or a production allowlist.
+Model availability is version-sensitive. Do not treat the example table as an exhaustive allowlist. Verify current identifiers against the [first-party Models and BYOK page](https://www.openui.com/docs/openui-cloud/models-and-byok), the console, or the generated template before changing `OPENUI_MODEL` or a production allowlist.
 
 A generated scaffold may use a managed/free model by default, for example:
 


### PR DESCRIPTION
## Summary

- mirror the BYOK model-support guidance from [thesysdev/openui#958](https://github.com/thesysdev/openui/pull/958)
- clarify that all models available from Anthropic, Google, and OpenAI are supported with BYOK
- make the model table explicitly non-exhaustive
- refresh the examples to include Claude Opus 5 and GPT-5.6 Sol
- remove older examples so the skill matches the concise first-party docs table

## Why

The skill still described its model table as the current BYOK list, which could be mistaken for an exhaustive support boundary. OpenUI PR #958 changed the first-party docs to make the provider-wide support model explicit and keep only three current examples per provider. This follow-up restores parity and prevents agents from treating the examples as a restrictive allowlist.

## Validation

- passed the skill creator's `quick_validate.py`
- `git diff --check`
- parsed `skills/openui/SKILL.md` frontmatter with Ruby YAML
- confirmed all nine examples from `thesysdev/openui#958` are present
- confirmed the retired examples are absent
- confirmed no credential material was introduced
